### PR TITLE
fix: $_POST['name']

### DIFF
--- a/10_get_post.php
+++ b/10_get_post.php
@@ -7,7 +7,7 @@
 
 if (isset($_POST['submit'])) {
   // echo '<h3>' . $GET['username'] . '</h3>';
-  echo '<h3>' . $_POST['username'] . '</h3>';
+  echo '<h3>' . $_POST['name'] . '</h3>';
 } ?>
 
 <!-- Pass data through a link -->


### PR DESCRIPTION
It currently refers to $_POST['username'], but the input field name attribute is called 'name', not 'username'.